### PR TITLE
Pre existing peers

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,14 @@ Node.prototype._onrequest = function (snapshot) {
     return
   }
 
+  // while rare, it is possible to see a peer we already knew about if we
+  // did not witness them disconnect before they attempted to reconnect
+  // if that happens we can destroy them in the same tick and respond
+  // to their request immediately
+  if (this.peers[peerId]) {
+    this.peers[peerId].destroy()
+  }
+
   debug(this.id + ' saw request by ' + peerId)
 
   var responseRef = requestRef.child('responses/' + this.id)


### PR DESCRIPTION
While rare, it is possible to see requests from a peer we think we are already connected to as we may not have witnessed them disconnect before they attempted to reconnect. If this happens we can destroy them in the same tick and respond to their request immediately.