### PR TITLE
Masking

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -20,7 +20,7 @@
         position: fixed;
         top: 36px;
         left: 36px;
-        font-size: 36px;
+        font-size: 28px;
       }
       .graph {
         position: absolute;
@@ -75,10 +75,7 @@
         color: #666;
         pointer-events: none;
         text-align: center;
-      }
-      .graph .nodes .node #label #branch {
-        font-size: 7px;
-        margin-top: 5px;
+        font-size: 12px;
       }
     </style>
   </head>

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,7 @@
 var fireflower = require('../')(require('firebase'))
 var Graph = require('./src/graph')
 
-window.root = fireflower('fireflower.firebaseio.com', { id: '0' })
+window.root = fireflower('fireflower.firebaseio.com', { root: true })
 window.root.connect()
 
 window.root.once('connect', function () {

--- a/example/src/node.js
+++ b/example/src/node.js
@@ -14,22 +14,21 @@ function NodeView (graph, model) {
   this.width = 30
   this.height = 30
 
-  this.el = hyperglue('<div class="node"><div id="circle"></div><div id="label"><div id="id"></div><div id="branch"></div></div></div>')
+  this.el = hyperglue('<div class="node"><div id="circle"></div><div id="label"></div></div>')
   this.el.querySelector('#circle').addEventListener('click', this.destroy.bind(this))
 }
 
 NodeView.prototype.render = function () {
   var self = this
   var ctx = this.graph.context
-  var upstream = this.graph.nodes[this.model.root && this.model.root.id]
+  var upstream = this.graph.nodes[this.model.upstream && this.model.upstream.id]
   var scale = isRetina ? 2 : 1
 
   hyperglue(this.el, {
     _attr: {
       'data-id': this.id
     },
-    '#label #id': this.id,
-    '#label #branch': this.model.branch
+    '#label': this.id
   })
 
   this.x = Math.min(this.x, this.graph.width)


### PR DESCRIPTION
Yet another attempt at preventing orphans, circles, and cascading disconnects.

The idea is to open an additional data channel between each node exclusively for pushing notifications downstream.

When a node loses its upstream connection, it pushes its `id` downstream over the notification channel before re-publishing its connection request - descendants then prevent circles from forming by ignoring any requests matching this "mask".

Since it may sometimes take more time for news about a mask to make it all the way downstream than for a request to be noticed, accidental circles can still occur - however when the news _does_ finally arrive, these circles can be recognized and broken.