### PR TITLE
Connection score

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,6 +277,9 @@ Node.prototype._onrequest = function (snapshot) {
   if (this.state !== 'connected' && this.state !== 'websocketconnected') {
     return // can't respond to requests unless we are connected
   }
+  if (!this.reportData || this.reportData.connection_score < 9) {
+    return // can't respond to requests unless our connection score is high enough
+  }
 
   this._beingRequested = true
 

--- a/index.js
+++ b/index.js
@@ -99,7 +99,9 @@ Node.prototype.connect = function () {
 
   // change state -> requesting
   if (this.state !== 'websocketconnected') {
-    debug(this.peerId + ' requesting connection')
+    if (this._requesting) {
+      debug(this.peerId + ' requesting connection')
+    }
     this.state = 'requesting'
     this.emit('statechange')
   }
@@ -209,7 +211,6 @@ Node.prototype._doconnect = function () {
     // emit connect but in nextTick
     this._setTimeout(function () {
       // change state -> connected
-      debug(self.peerId + ' connected as websocket peer')
       self.state = 'websocketconnected'
       self.emit('statechange')
 


### PR DESCRIPTION
Connection score is now required, and the given peer's score must be at least 9 to respond to requests.